### PR TITLE
FFM-12078 Bump `hackney` and pin dependencies 

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,12 @@
 {erl_opts, [debug_info, warnings_as_errors, warn_untyped_record]}.
 
-{deps, [ctx, jsx, hackney]}.
+{
+  deps,
+  [
+    {ctx, "0.6.0"},
+    {jsx, "3.1.0"},
+    {hackney, "1.20.1"}
+  ]}.
 
 {shell, [{apps, [cfapi]}]}.
 

--- a/src/cfapi.app.src
+++ b/src/cfapi.app.src
@@ -1,6 +1,6 @@
 {application, cfapi,
  [{description, "OpenAPI Client libary for Harness Feature Flags Erlang Server SDK"},
-  {vsn, "1.0.1"},
+  {vsn, "1.0.2"},
   {pkg_name, "harness_ff_erlang_client_api"},
   {registered, []},
   {applications,


### PR DESCRIPTION
# What
- Bumps `hackney` to latest version 1.20.1
- Pins `jsx` and `ctx` to latest versions

# Testing
Used git dependency in the erlang-server-sdk and tested in TestGrid application