### PR TITLE
fix: [12712]: Better handling of Content-Type header with mixed-case

### DIFF
--- a/src/cfapi.app.src
+++ b/src/cfapi.app.src
@@ -1,6 +1,6 @@
 {application, cfapi,
  [{description, "OpenAPI Client libary for Harness Feature Flags Erlang Server SDK"},
-  {vsn, "1.0.3"},
+  {vsn, "1.0.4"},
   {pkg_name, "harness_ff_erlang_client_api"},
   {registered, []},
   {applications,

--- a/src/cfapi_utils.erl
+++ b/src/cfapi_utils.erl
@@ -40,7 +40,8 @@ request(_Ctx, Method, Path, QS, Headers, Body, Opts, Cfg) ->
     end.
 
 decode_response(Headers, Body) ->
-    case lists:keyfind(<<"Content-Type">>, 1, Headers) of
+    Headers1 = to_lower(Headers),
+    case lists:keyfind(<<"content-type">>, 1, Headers1) of
         {_, <<"application/json", _/binary>>} ->
             jsx:decode(Body, [return_maps, {labels, atom}]);
         %% TODO: yml, protobuf, user defined function
@@ -96,3 +97,9 @@ update_params_with_auth(Cfg, Headers, QS) ->
                               end
                       end
               end, {Headers, QS}, Auths).
+
+to_lower(TupleList) ->
+  lists:map(fun(Tuple) ->
+              LowercasedFirst = string:lowercase(element(1, Tuple)),
+              setelement(1, Tuple, LowercasedFirst)
+            end, TupleList).


### PR DESCRIPTION
- Customers are reporting crashes in the field
- Proxy is sending lowercase headers which results in the following error `failed_to_start_child -> cfclient_instance -> case_clause` on auth
- The code originates from the OpenAPI generator. This is a temporary fix to the generated code. A proper fix will be to upgrade the generator to a version that handles any case of header.